### PR TITLE
update baseurl to a more generic one

### DIFF
--- a/src/polygonjs/scenes/Scene01.tsx
+++ b/src/polygonjs/scenes/Scene01.tsx
@@ -14,6 +14,7 @@ export const Scene01 = () => {
 			loadFunction={loadScene_scene_01}
 			onSceneReady={onSceneReady_01}
 			render={true}
+			baseUrl="./"
 		/>
 	);
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: 'plantas-baixas-3d'
+  base: './'
 })


### PR DESCRIPTION
using `./` as a baseUrl, both in vite.config and the polygonjs component will allow you to load the scene from the root folder as well as a sub folder.

Although I've just checked and when loading from a sub folder, the loading image still has an incorrect path, so I'd have to look into that. In the mean time, this is one path you would have to change manually unfortunately. 